### PR TITLE
Feature Request: Add aws profile switching.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	rootCmd.AddCommand(loginCmd)
 	loginCmd.Flags().StringVarP(&roleArn, "role-arn", "r", "", "login with the specified role ARN instead of asking for the role you want to login with")
-	loginCmd.Flags().StringVarP(&awsProfile, "aws-profile", "p", "keyhub", "aws profile to write the credentials to")
+	loginCmd.Flags().StringVarP(&profile, "profile", "p", "keyhub", "aws profile to write the credentials to")
 }
 
 var loginCmd = &cobra.Command{
@@ -26,7 +26,7 @@ var loginCmd = &cobra.Command{
 }
 
 var roleArn string
-var awsProfile string
+var profile string
 
 func login() {
 	aws_keyhub.CheckIfAwsKeyHubConfigFileExists()
@@ -43,7 +43,7 @@ func login() {
 	selectedRoleAndPrincipal := aws_keyhub.SelectRoleAndPrincipal(roleArn, rolesAndPrincipals)
 	samlOutput = aws_keyhub.StsAssumeRoleWithSAML(selectedRoleAndPrincipal.Principal, selectedRoleAndPrincipal.Role, exchangeTokenResponse.AccessToken)
 
-	aws_keyhub.WriteCredentialFile(awsProfile, samlOutput.Credentials)
-	aws_keyhub.VerifyIfLoginWasSuccessful(awsProfile, selectedRoleAndPrincipal.Role)
-	logrus.Infof("Successfully logged in, use the AWS profile `%[1]s`. (export AWS_PROFILE=%[1]s / set AWS_PROFILE=%[1]s / $env:AWS_PROFILE='%[1]s')", awsProfile)
+	aws_keyhub.WriteCredentialFile(profile, samlOutput.Credentials)
+	aws_keyhub.VerifyIfLoginWasSuccessful(profile, selectedRoleAndPrincipal.Role)
+	logrus.Infof("Successfully logged in, use the AWS profile `%[1]s`. (export AWS_PROFILE=%[1]s / set AWS_PROFILE=%[1]s / $env:AWS_PROFILE='%[1]s')", profile)
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -10,6 +10,7 @@ import (
 func init() {
 	rootCmd.AddCommand(loginCmd)
 	loginCmd.Flags().StringVarP(&roleArn, "role-arn", "r", "", "login with the specified role ARN instead of asking for the role you want to login with")
+	loginCmd.Flags().StringVarP(&awsProfile, "aws-profile", "p", "keyhub", "aws profile to write the credentials to")
 }
 
 var loginCmd = &cobra.Command{
@@ -25,6 +26,7 @@ var loginCmd = &cobra.Command{
 }
 
 var roleArn string
+var awsProfile string
 
 func login() {
 	aws_keyhub.CheckIfAwsKeyHubConfigFileExists()
@@ -41,7 +43,7 @@ func login() {
 	selectedRoleAndPrincipal := aws_keyhub.SelectRoleAndPrincipal(roleArn, rolesAndPrincipals)
 	samlOutput = aws_keyhub.StsAssumeRoleWithSAML(selectedRoleAndPrincipal.Principal, selectedRoleAndPrincipal.Role, exchangeTokenResponse.AccessToken)
 
-	aws_keyhub.WriteCredentialFile(samlOutput.Credentials)
-	aws_keyhub.VerifyIfLoginWasSuccessful(selectedRoleAndPrincipal.Role)
-	logrus.Infoln("Successfully logged in, use the AWS profile `keyhub`. (export AWS_PROFILE=keyhub / set AWS_PROFILE=keyhub / $env:AWS_PROFILE='keyhub')")
+	aws_keyhub.WriteCredentialFile(awsProfile, samlOutput.Credentials)
+	aws_keyhub.VerifyIfLoginWasSuccessful(awsProfile, selectedRoleAndPrincipal.Role)
+	logrus.Infof("Successfully logged in, use the AWS profile `%[1]s`. (export AWS_PROFILE=%[1]s / set AWS_PROFILE=%[1]s / $env:AWS_PROFILE='%[1]s')", awsProfile)
 }

--- a/pkg/aws_keyhub/aws.go
+++ b/pkg/aws_keyhub/aws.go
@@ -84,7 +84,6 @@ func WriteCredentialFile(profile string, credentials *sts.Credentials) {
 
 	cfg.SaveTo(credentialFilePath)
 	logrus.Debugf("Credentials saved to '%s' under profile section: [%s]", credentialFilePath, profile)
-	logrus.Infof("Successfully logged in, use the AWS profile `%[1]s`. (export AWS_PROFILE=%[1]s / set AWS_PROFILE=%[1]s / $env:AWS_PROFILE='%[1]s')", profile)
 }
 
 func createNewKeyInSection(sec *ini.Section, key string, value string) {

--- a/pkg/aws_keyhub/aws.go
+++ b/pkg/aws_keyhub/aws.go
@@ -31,9 +31,9 @@ func StsAssumeRoleWithSAML(principalArn string, roleArn string, samlAssertion st
 	return result
 }
 
-func VerifyIfLoginWasSuccessful(awsProfile string, roleArn string) {
+func VerifyIfLoginWasSuccessful(profile string, roleArn string) {
 
-	credentialsFromFile := credentials.NewSharedCredentials(getCredentialFilePath(), awsProfile)
+	credentialsFromFile := credentials.NewSharedCredentials(getCredentialFilePath(), profile)
 	config := &aws.Config{Credentials: credentialsFromFile}
 	newSession, _ := session.NewSession(config)
 	svc := sts.New(newSession)
@@ -64,7 +64,7 @@ func CheckIfAwsConfigFileExists() {
 	logrus.Debugln("AWS configuration file exists.")
 }
 
-func WriteCredentialFile(awsProfile string, credentials *sts.Credentials) {
+func WriteCredentialFile(profile string, credentials *sts.Credentials) {
 	accessKeyId := *credentials.AccessKeyId
 	secretAccessKey := *credentials.SecretAccessKey
 	sessionToken := *credentials.SessionToken
@@ -77,12 +77,14 @@ func WriteCredentialFile(awsProfile string, credentials *sts.Credentials) {
 		logrus.Fatal("Failed to read credentials file:", err)
 	}
 
-	sec := cfg.Section(awsProfile) // Auto-create if not exists
+	sec := cfg.Section(profile) // Auto-create if not exists
 	createNewKeyInSection(sec, "aws_access_key_id", accessKeyId)
 	createNewKeyInSection(sec, "aws_secret_access_key", secretAccessKey)
 	createNewKeyInSection(sec, "aws_session_token", sessionToken)
 
 	cfg.SaveTo(credentialFilePath)
+	logrus.Debugf("Credentials saved to '%s' under profile section: [%s]", credentialFilePath, profile)
+	logrus.Infof("Successfully logged in, use the AWS profile `%[1]s`. (export AWS_PROFILE=%[1]s / set AWS_PROFILE=%[1]s / $env:AWS_PROFILE='%[1]s')", profile)
 }
 
 func createNewKeyInSection(sec *ini.Section, key string, value string) {

--- a/pkg/aws_keyhub/aws.go
+++ b/pkg/aws_keyhub/aws.go
@@ -31,9 +31,9 @@ func StsAssumeRoleWithSAML(principalArn string, roleArn string, samlAssertion st
 	return result
 }
 
-func VerifyIfLoginWasSuccessful(roleArn string) {
+func VerifyIfLoginWasSuccessful(awsProfile string, roleArn string) {
 
-	credentialsFromFile := credentials.NewSharedCredentials(getCredentialFilePath(), "keyhub")
+	credentialsFromFile := credentials.NewSharedCredentials(getCredentialFilePath(), awsProfile)
 	config := &aws.Config{Credentials: credentialsFromFile}
 	newSession, _ := session.NewSession(config)
 	svc := sts.New(newSession)
@@ -64,7 +64,7 @@ func CheckIfAwsConfigFileExists() {
 	logrus.Debugln("AWS configuration file exists.")
 }
 
-func WriteCredentialFile(credentials *sts.Credentials) {
+func WriteCredentialFile(awsProfile string, credentials *sts.Credentials) {
 	accessKeyId := *credentials.AccessKeyId
 	secretAccessKey := *credentials.SecretAccessKey
 	sessionToken := *credentials.SessionToken
@@ -77,7 +77,7 @@ func WriteCredentialFile(credentials *sts.Credentials) {
 		logrus.Fatal("Failed to read credentials file:", err)
 	}
 
-	sec := cfg.Section("keyhub") // Auto-create if not exists
+	sec := cfg.Section(awsProfile) // Auto-create if not exists
 	createNewKeyInSection(sec, "aws_access_key_id", accessKeyId)
 	createNewKeyInSection(sec, "aws_secret_access_key", secretAccessKey)
 	createNewKeyInSection(sec, "aws_session_token", sessionToken)


### PR DESCRIPTION
Hi keyhub team!

## Feature Request: 
**Add possiblity to change aws profile instead of hardcoded 'keyhub'**
### Problem description.
As a lover of the terminal I have automated several common actions using zsh functions
among them I use some zsh functions around aws-keyhub to login selecting the right role using `--role-arn`
customizing my zsh prompt and selecting the correct eks cluster for kubectl.

This has been working pretty well! But it I have come across some quirks with such a workflow.
As tasks running over a portforwarded bastion host would not reconnect if the aws 'keyhub' profile changes.

### Solution
Using the same approach as `--role-arn` creating a `--profile` flag to specify / customize 
what profile the credentials get written to. 

This would simplify users automating using scripting around aws-keyhub.

### Other notes
As the new flag defaults to `keyhub` this change would not impact current usage of aws-keyhub
but allow users to change the profile if they wish to.